### PR TITLE
feat: use types instead of classes with ItemDeserializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ type File = {
 }
 
 // Create a deserializer for the folder:
-const FolderDeserializer : ItemDeserializer<Folder> = {
+const folderDeserializer : ItemDeserializer<Folder> = {
     type: 'folders',
     deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Folder => {
         const folder: Folder = {
@@ -47,7 +47,7 @@ const FolderDeserializer : ItemDeserializer<Folder> = {
 }
 
 // ...and also for the file:
-const FileDeserializer: ItemDeserializer<File> = {
+const fileDeserializer: ItemDeserializer<File> = {
     type: 'files',
     deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): File => {
         return {
@@ -59,8 +59,8 @@ const FileDeserializer: ItemDeserializer<File> = {
 
 // create the deserializer with the folder and file deserializers registered:
 const deserializer = getDeserializer([
-    FolderDeserializer,
-    FileDeserializer,
+    folderDeserializer,
+    fileDeserializer,
 ]);
 
 // Fetch your JSON:API data:

--- a/README.md
+++ b/README.md
@@ -31,12 +31,9 @@ type File = {
 }
 
 // Create a deserializer for the folder:
-class FolderDeserializer implements ItemDeserializer {
-    getType(): string {
-        return 'folders';
-    }
-
-    deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const FolderDeserializer : ItemDeserializer<Folder> = {
+    type: 'folders',
+    deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Folder => {
         const folder: Folder = {
             id: parseInt(item.id),
             name: item.attributes.name,
@@ -46,16 +43,13 @@ class FolderDeserializer implements ItemDeserializer {
         folder.children = relationshipDeserializer.deserializeRelationships(relationshipDeserializer, item, 'children');
 
         return folder;
-    }
+    },
 }
 
 // ...and also for the file:
-class FileDeserializer implements ItemDeserializer {
-    getType(): string {
-        return 'files';
-    }
-
-    deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const FileDeserializer: ItemDeserializer<File> = {
+    type: 'files',
+    deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): File => {
         return {
             id: parseInt(item.id),
             name: item.attributes.name,
@@ -65,8 +59,8 @@ class FileDeserializer implements ItemDeserializer {
 
 // create the deserializer with the folder and file deserializers registered:
 const deserializer = getDeserializer([
-    new FolderDeserializer(),
-    new FileDeserializer(),
+    FolderDeserializer,
+    FileDeserializer,
 ]);
 
 // Fetch your JSON:API data:
@@ -85,7 +79,7 @@ const rootItems: any[] = deserializer.consume(yourJsonData).getRootItems();
 
 At least the following things are in the backlog:
 
-* [ ] Ditch the classes in the entity deserializers and use types instead
+* [X] Ditch the classes in the entity deserializers and use types instead
 * [ ] Consider caching the deserialized entities and reusing them
 * [ ] Come up with a spectacular logo for this package
 

--- a/src/__tests__/Deserializer.test.ts
+++ b/src/__tests__/Deserializer.test.ts
@@ -115,12 +115,9 @@ type Comment = {
   author?: Person;
 };
 
-class ArticleDeserializer implements ItemDeserializer {
-  getType(): string {
-    return 'articles';
-  }
-
-  deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const ArticleDeserializer : ItemDeserializer<Article> = {
+  type: 'articles',
+  deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Article => {
     const article: Article = {
       id: parseInt(item.id),
       title: item.attributes.title,
@@ -134,27 +131,21 @@ class ArticleDeserializer implements ItemDeserializer {
   }
 }
 
-class PersonDeserializer implements ItemDeserializer {
-  getType(): string {
-    return 'people';
-  }
-
-  deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const PersonDeserializer : ItemDeserializer<Person> = {
+  type: 'people',
+  deserialize: (item: Item, _: RelationshipDeserializer): Person => {
     return {
       id: parseInt(item.id),
       firstName: item.attributes.firstName,
       lastName: item.attributes.lastName,
       twitter: item.attributes.twitter,
-    };
-  }
+    }
+  },
 }
 
-class CommentDeserializer implements ItemDeserializer {
-  getType(): string {
-    return 'comments';
-  }
-
-  deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const CommentDeserializer : ItemDeserializer<Comment> = {
+  type: 'comments',
+  deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Comment => {
     const comment: Comment = {
       id: parseInt(item.id),
       body: item.attributes.body,
@@ -316,12 +307,9 @@ type File = {
   name: string;
 };
 
-class FolderDeserializer implements ItemDeserializer {
-  getType(): string {
-    return 'folders';
-  }
-
-  deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const FolderDeserializer : ItemDeserializer<Folder> = {
+  type: 'folders',
+  deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Folder => {
     const folder: Folder = {
       id: parseInt(item.id),
       name: item.attributes.name,
@@ -331,15 +319,12 @@ class FolderDeserializer implements ItemDeserializer {
     folder.children = relationshipDeserializer.deserializeRelationships(relationshipDeserializer, item, 'children');
 
     return folder;
-  }
+  },
 }
 
-class FileDeserializer implements ItemDeserializer {
-  getType(): string {
-    return 'files';
-  }
-
-  deserialize(item: Item, relationshipDeserializer: RelationshipDeserializer): any {
+const FileDeserializer: ItemDeserializer<File> = {
+  type: 'files',
+  deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): File => {
     return {
       id: parseInt(item.id),
       name: item.attributes.name,
@@ -349,10 +334,10 @@ class FileDeserializer implements ItemDeserializer {
 
 describe('Deserializer', () => {
   it('deserializes the jsonapi.org example into an object graph', () => {
-    const deserializer = getDeserializer([
-      new ArticleDeserializer(),
-      new PersonDeserializer(),
-      new CommentDeserializer(),
+    const deserializer : Deserializer = getDeserializer([
+      ArticleDeserializer,
+      PersonDeserializer,
+      CommentDeserializer,
     ]);
 
     const rootItems: any[] = deserializer.consume(jsonapiOrgExampleData).getRootItems();
@@ -361,7 +346,7 @@ describe('Deserializer', () => {
   });
 
   it('deserializes a file system example into an object graph', () => {
-    const deserializer = getDeserializer([new FolderDeserializer(), new FileDeserializer()]);
+    const deserializer : Deserializer = getDeserializer([FolderDeserializer, FileDeserializer]);
 
     const rootItems: any[] = deserializer.consume(fileSystemExampleData).getRootItems();
 
@@ -369,7 +354,7 @@ describe('Deserializer', () => {
   });
 
   it('deserializes the second file system example (single entity) into an object graph', () => {
-    const deserializer = getDeserializer([new FolderDeserializer(), new FileDeserializer()]);
+    const deserializer : Deserializer = getDeserializer([FolderDeserializer, FileDeserializer]);
 
     const rootItem: Folder = deserializer.consume(fileSystemExampleData2).getRootItem();
 

--- a/src/__tests__/Deserializer.test.ts
+++ b/src/__tests__/Deserializer.test.ts
@@ -115,7 +115,7 @@ type Comment = {
   author?: Person;
 };
 
-const ArticleDeserializer : ItemDeserializer<Article> = {
+const articleDeserializer : ItemDeserializer<Article> = {
   type: 'articles',
   deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Article => {
     const article: Article = {
@@ -131,7 +131,7 @@ const ArticleDeserializer : ItemDeserializer<Article> = {
   }
 }
 
-const PersonDeserializer : ItemDeserializer<Person> = {
+const personDeserializer : ItemDeserializer<Person> = {
   type: 'people',
   deserialize: (item: Item, _: RelationshipDeserializer): Person => {
     return {
@@ -143,7 +143,7 @@ const PersonDeserializer : ItemDeserializer<Person> = {
   },
 }
 
-const CommentDeserializer : ItemDeserializer<Comment> = {
+const commentDeserializer : ItemDeserializer<Comment> = {
   type: 'comments',
   deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Comment => {
     const comment: Comment = {
@@ -307,7 +307,7 @@ type File = {
   name: string;
 };
 
-const FolderDeserializer : ItemDeserializer<Folder> = {
+const folderDeserializer : ItemDeserializer<Folder> = {
   type: 'folders',
   deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): Folder => {
     const folder: Folder = {
@@ -322,7 +322,7 @@ const FolderDeserializer : ItemDeserializer<Folder> = {
   },
 }
 
-const FileDeserializer: ItemDeserializer<File> = {
+const fileDeserializer: ItemDeserializer<File> = {
   type: 'files',
   deserialize: (item: Item, relationshipDeserializer: RelationshipDeserializer): File => {
     return {
@@ -335,9 +335,9 @@ const FileDeserializer: ItemDeserializer<File> = {
 describe('Deserializer', () => {
   it('deserializes the jsonapi.org example into an object graph', () => {
     const deserializer : Deserializer = getDeserializer([
-      ArticleDeserializer,
-      PersonDeserializer,
-      CommentDeserializer,
+      articleDeserializer,
+      personDeserializer,
+      commentDeserializer,
     ]);
 
     const rootItems: any[] = deserializer.consume(jsonapiOrgExampleData).getRootItems();
@@ -346,7 +346,7 @@ describe('Deserializer', () => {
   });
 
   it('deserializes a file system example into an object graph', () => {
-    const deserializer : Deserializer = getDeserializer([FolderDeserializer, FileDeserializer]);
+    const deserializer : Deserializer = getDeserializer([folderDeserializer, fileDeserializer]);
 
     const rootItems: any[] = deserializer.consume(fileSystemExampleData).getRootItems();
 
@@ -354,7 +354,7 @@ describe('Deserializer', () => {
   });
 
   it('deserializes the second file system example (single entity) into an object graph', () => {
-    const deserializer : Deserializer = getDeserializer([FolderDeserializer, FileDeserializer]);
+    const deserializer : Deserializer = getDeserializer([folderDeserializer, fileDeserializer]);
 
     const rootItem: Folder = deserializer.consume(fileSystemExampleData2).getRootItem();
 


### PR DESCRIPTION
BREAKING CHANGE: ItemDeserializer is now a type and not an interface

The ItemSerializer needs to be implemented by having a type that contains the "type" and "deserialize" also supporting generics with the deserialize return value. See the updated documentation on README.md for details.