### PR TITLE
add support for skipping unknown entities in deserializer

### DIFF
--- a/src/__tests__/__snapshots__/Deserializer.spec.ts.snap
+++ b/src/__tests__/__snapshots__/Deserializer.spec.ts.snap
@@ -114,34 +114,6 @@ exports[`Deserializer deserializes the third file system example (single entity 
 }
 `;
 
-exports[`Deserializer skipUnkownEntities = true does not throw an error when serializer is not found for entity and save the unknown entity type 1`] = `
-{
-  "children": [
-    {
-      "children": [
-        {
-          "id": 4,
-          "name": "README.md",
-        },
-        {
-          "children": [],
-          "id": 5,
-          "name": "juha",
-        },
-      ],
-      "id": 2,
-      "name": "home",
-    },
-    {
-      "id": 3,
-      "name": "swapfile",
-    },
-  ],
-  "id": 1,
-  "name": "root",
-}
-`;
-
 exports[`Deserializer skipUnkownEntities = true does not throw an error when serializer is not found for entity and save the unknown entity type when deserializing array 1`] = `
 [
   {

--- a/src/__tests__/__snapshots__/Deserializer.spec.ts.snap
+++ b/src/__tests__/__snapshots__/Deserializer.spec.ts.snap
@@ -113,3 +113,89 @@ exports[`Deserializer deserializes the third file system example (single entity 
   "name": "root",
 }
 `;
+
+exports[`Deserializer skipUnkownEntities = true does not throw an error when serializer is not found for entity and save the unknown entity type 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "id": 4,
+          "name": "README.md",
+        },
+        {
+          "children": [],
+          "id": 5,
+          "name": "juha",
+        },
+      ],
+      "id": 2,
+      "name": "home",
+    },
+    {
+      "id": 3,
+      "name": "swapfile",
+    },
+  ],
+  "id": 1,
+  "name": "root",
+}
+`;
+
+exports[`Deserializer skipUnkownEntities = true does not throw an error when serializer is not found for entity and save the unknown entity type when deserializing array 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "id": 4,
+            "name": "README.md",
+          },
+          {
+            "children": [],
+            "id": 5,
+            "name": "juha",
+          },
+        ],
+        "id": 2,
+        "name": "home",
+      },
+      {
+        "id": 3,
+        "name": "swapfile",
+      },
+    ],
+    "id": 1,
+    "name": "root",
+  },
+]
+`;
+
+exports[`Deserializer skipUnkownEntities = true does not throw an error when serializer is not found for entity and save the unknown entity type when deserializing object 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "id": 4,
+          "name": "README.md",
+        },
+        {
+          "children": [],
+          "id": 5,
+          "name": "juha",
+        },
+      ],
+      "id": 2,
+      "name": "home",
+    },
+    {
+      "id": 3,
+      "name": "swapfile",
+    },
+  ],
+  "id": 1,
+  "name": "root",
+}
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,8 +301,12 @@ export class Deserializer implements RelationshipDeserializer {
       throw new Error('JSON-object must contain key `data`');
     }
 
-    this.rootItems = {};
-    this.entityStoreCollection = {};
+    // When skipUnknownEntities is true, we need to reset the rootItems and entityStoreCollection
+    // so that we can keep track of the skipped entities with each deserialization.
+    if (this.skipUnknownEntities) {
+      this.rootItems = {};
+      this.entityStoreCollection = {};
+    }
 
     if (Array.isArray(json.data)) {
       json.data.forEach((item: Item) => {


### PR DESCRIPTION
This change adds a possibility to skip entities that don't have a deserializer registered. Those unknown entities are then saved and available for the caller via `getSkippedEntities` until next deserialization (`getRootItem(s)` call).